### PR TITLE
[WIP] Fix neck dropping

### DIFF
--- a/mohou_ros_utils/pr2/executor.py
+++ b/mohou_ros_utils/pr2/executor.py
@@ -11,19 +11,19 @@ from mohou_ros_utils.executor import ExecutorBase
 from mohou_ros_utils.pr2.controller_utils import check_pr2_is_executable
 
 
-class RarmInterface(PR2ROSRobotInterface):
+class ArmInterface(PR2ROSRobotInterface):
     def default_controller(self):
-        return [self.rarm_controller]
+        return [self.rarm_controller, self.larm_controller]  # self.torso_controller
 
 
 class SkrobotPR2Executor(ExecutorBase):
     robot_model: PR2
-    robot_interface: RarmInterface
+    robot_interface: ArmInterface
 
     def _post_init(self):
         robot_model = PR2()
         self.robot_model = robot_model
-        self.robot_interface = RarmInterface(robot_model)
+        self.robot_interface = ArmInterface(robot_model)
         self.robot_model.angle_vector(self.robot_interface.angle_vector())
         check_pr2_is_executable()
 

--- a/mohou_ros_utils/pr2/executor.py
+++ b/mohou_ros_utils/pr2/executor.py
@@ -11,14 +11,19 @@ from mohou_ros_utils.executor import ExecutorBase
 from mohou_ros_utils.pr2.controller_utils import check_pr2_is_executable
 
 
+class RarmInterface(PR2ROSRobotInterface):
+    def default_controller(self):
+        return [self.rarm_controller]
+
+
 class SkrobotPR2Executor(ExecutorBase):
     robot_model: PR2
-    robot_interface: PR2ROSRobotInterface
+    robot_interface: RarmInterface
 
     def _post_init(self):
         robot_model = PR2()
         self.robot_model = robot_model
-        self.robot_interface = PR2ROSRobotInterface(robot_model)
+        self.robot_interface = RarmInterface(robot_model)
         self.robot_model.angle_vector(self.robot_interface.angle_vector())
         check_pr2_is_executable()
 


### PR DESCRIPTION
Limiting the number of controllers to be loaded fixes the problem of the robot's head going down during the execution of the skill.  

[WIP] : Unconfirmed, e.g., whether it is possible to use both arms for execution, etc.